### PR TITLE
Housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,35 @@
-eclipse/
-build/
-.gradle/
-*.iml
+# eclipse
+eclipse
+bin
+*.launch
+.settings
+.metadata
+.classpath
+.project
+
+# idea
+out
 *.ipr
 *.iws
-forge-*-changelog.txt
-out/
-.idea
+*.iml
+.idea/*
+!.idea/codeStyles
+
+# gradle
+build
+.gradle
+
+#Netbeans
+.nb-gradle
+.nb-gradle-properties
+
+# other
+run
+.DS_Store
+Thumbs.db
+remappedSrc
+logs
+*.hprof
+generated
+.vscode
+/test

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,12 @@ buildscript {
             name = "sonatype"
             url = "https://oss.sonatype.org/content/repositories/snapshots/"
         }
+	    maven {
+            url = "https://jitpack.io"
+        }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.13'
     }
 }
 apply plugin: 'forge'


### PR DESCRIPTION
- Add in [the 1.19 branch's .gitignore](https://github.com/DimensionalDevelopment/DimDoors/blob/559f6a5c2d0e0cd110d8c5c94d58ac84d6d7fd5e/.gitignore) (fixes Eclipse files not being ignored)
- Use GTNH fork of ForgeGradle (fixes build)